### PR TITLE
Use local IPFS gateway if available

### DIFF
--- a/frontend/scripts/search.js
+++ b/frontend/scripts/search.js
@@ -21,6 +21,16 @@ module.exports = {
         result_container = $('#result-container'),
         page_number = $('#page-number');
 
+    search_form.data('ipfs-gateway', 'https://gateway.ipfs.io');
+
+    var gateway_promise = $.get({'url': 'http://localhost:8080/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/ping', 'cache': false});
+
+    gateway_promise.done(function (result) {
+      if (result === 'ipfs') {
+        search_form.data('ipfs-gateway', 'http://localhost:8080');
+      }
+    });
+
     function get_results(params) {
       // Show blocker for longer waits
 
@@ -34,6 +44,8 @@ module.exports = {
       );
 
       result_promise.done(function (results) {
+
+        results.gateway = search_form.data('ipfs-gateway');
 
         result_container.html(result_template(results));
 

--- a/frontend/templates/results.hbs
+++ b/frontend/templates/results.hbs
@@ -7,7 +7,7 @@
       {{#each hits}}
         <div>
           <h2>
-            <a target="_blank" href="https://gateway.ipfs.io/ipfs/{{hash}}">
+            <a target="_blank" href="{{../gateway}}/ipfs/{{hash}}">
               <img height="24" width="24" src="assets/{{type}}.svg">
               {{{ title }}}
             </a>


### PR DESCRIPTION
If there is an IPFS gateway running on localhost, that gateway should be used instead of https://gateway.ipfs.io.

On page load a xhr request to `http://localhost:8080/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/ping` is sent. If the response is `ipfs`, it is most likely a working IPFS gateway. The pinged document comes from IPFS itself: https://github.com/ipfs/go-ipfs/blob/v0.4.13/test/sharness/lib/test-lib-hashes.sh