### PR TITLE
Upgrade certbot ahead of CME TLS-SNI-01 removal

### DIFF
--- a/deployment/roles/certbot/tasks/main.yml
+++ b/deployment/roles/certbot/tasks/main.yml
@@ -8,6 +8,10 @@
     repo: 'ppa:certbot/certbot'
 - name: certbot installed
   apt:
+    name: certbot
+    state: latest
+- name: python-certbot-nginx installed
+  apt:
     name: python-certbot-nginx
     state: latest
 - name: setup certificates


### PR DESCRIPTION
Apparently I need to mention certbot explicitly for the upgrade to actually take place.