### PR TITLE
Discriminate source of resources, do not update last seen of directories

### DIFF
--- a/commands/add.go
+++ b/commands/add.go
@@ -54,11 +54,13 @@ func AddHash(ctx context.Context, cfg *config.Config, hash string) error {
 		ID:       hash,
 	}
 
-	provider := t.Provider{
+	r := t.AnnotatedResource{
 		Resource: resource,
-		Date:     time.Now(),
+		Source:   t.ManualSource,
 	}
 
+	// TODO: Use provider here
+
 	// Add with highest priority, as this is supposed to be available
-	return queue.Publish(ctx, provider, 9)
+	return queue.Publish(ctx, &r, 9)
 }

--- a/components/crawler/crawler_test.go
+++ b/components/crawler/crawler_test.go
@@ -933,7 +933,8 @@ func (s *CrawlerTestSuite) TestCrawlUpdateLastSeen() {
 		On("Get", mock.Anything, r.Resource.ID, &indexTypes.Update{}, []string{"references", "last-seen"}).
 		Run(func(args mock.Arguments) {
 			u := args.Get(2).(*indexTypes.Update)
-			u.LastSeen = time.Now().Add(-2 * time.Hour)
+			lastSeen := time.Now().Add(-2 * time.Hour)
+			u.LastSeen = &lastSeen
 		}).
 		Return(true, nil).
 		Once()
@@ -951,7 +952,7 @@ func (s *CrawlerTestSuite) TestCrawlUpdateLastSeen() {
 	s.fileIdx.
 		On("Update", mock.Anything, r.Resource.ID, mock.MatchedBy(func(u *indexTypes.Update) bool {
 			return s.Empty(u.References) &&
-				s.WithinDuration(u.LastSeen, time.Now(), time.Second)
+				s.WithinDuration(*u.LastSeen, time.Now(), time.Second)
 		})).
 		Return(nil).
 		Once()
@@ -1004,6 +1005,7 @@ func (s *CrawlerTestSuite) TestCrawlAddReference() {
 			Protocol: t.IPFSProtocol,
 			ID:       "QmSKboVigcD3AY4kLsob117KJcMHvMUu6vNFqk1PQzYUpp",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: &t.Resource{
 				Protocol: t.IPFSProtocol,
@@ -1018,7 +1020,8 @@ func (s *CrawlerTestSuite) TestCrawlAddReference() {
 		On("Get", mock.Anything, r.Resource.ID, &indexTypes.Update{}, []string{"references", "last-seen"}).
 		Run(func(args mock.Arguments) {
 			u := args.Get(2).(*indexTypes.Update)
-			u.LastSeen = time.Now()
+			lastSeen := time.Now()
+			u.LastSeen = &lastSeen
 			u.References = indexTypes.References{
 				indexTypes.Reference{
 					ParentHash: "Qmc8mmzycvXnzgwBHokZQd97iWAmtdFMqX4FZUAQ5AQdQi",
@@ -1050,8 +1053,7 @@ func (s *CrawlerTestSuite) TestCrawlAddReference() {
 					ParentHash: "QmYAqhbqNDpU7X9VW6FV5imtngQ3oBRY35zuDXduuZnyA8",
 					Name:       "NewReference.pdf",
 				},
-			}) &&
-				s.WithinDuration(u.LastSeen, time.Now(), time.Second)
+			}) && u.LastSeen == nil
 		})).
 		Return(nil).
 		Once()
@@ -1071,6 +1073,7 @@ func (s *CrawlerTestSuite) TestCrawlUpdateGetError() {
 			Protocol: t.IPFSProtocol,
 			ID:       "QmSKboVigcD3AY4kLsob117KJcMHvMUu6vNFqk1PQzYUpp",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: &t.Resource{
 				Protocol: t.IPFSProtocol,
@@ -1112,6 +1115,7 @@ func (s *CrawlerTestSuite) TestCrawlUpdateUpdateError() {
 			Protocol: t.IPFSProtocol,
 			ID:       "QmSKboVigcD3AY4kLsob117KJcMHvMUu6vNFqk1PQzYUpp",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: &t.Resource{
 				Protocol: t.IPFSProtocol,
@@ -1126,7 +1130,8 @@ func (s *CrawlerTestSuite) TestCrawlUpdateUpdateError() {
 		On("Get", mock.Anything, r.Resource.ID, &indexTypes.Update{}, []string{"references", "last-seen"}).
 		Run(func(args mock.Arguments) {
 			u := args.Get(2).(*indexTypes.Update)
-			u.LastSeen = time.Now()
+			lastSeen := time.Now()
+			u.LastSeen = &lastSeen
 			u.References = indexTypes.References{
 				indexTypes.Reference{
 					ParentHash: "Qmc8mmzycvXnzgwBHokZQd97iWAmtdFMqX4FZUAQ5AQdQi",
@@ -1160,8 +1165,7 @@ func (s *CrawlerTestSuite) TestCrawlUpdateUpdateError() {
 					ParentHash: "QmYAqhbqNDpU7X9VW6FV5imtngQ3oBRY35zuDXduuZnyA8",
 					Name:       "NewReference.pdf",
 				},
-			}) &&
-				s.WithinDuration(u.LastSeen, time.Now(), time.Second)
+			}) && u.LastSeen == nil
 		})).
 		Return(testErr).
 		Once()
@@ -1181,6 +1185,7 @@ func (s *CrawlerTestSuite) TestCrawlSameReference() {
 			Protocol: t.IPFSProtocol,
 			ID:       "QmSKboVigcD3AY4kLsob117KJcMHvMUu6vNFqk1PQzYUpp",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: &t.Resource{
 				Protocol: t.IPFSProtocol,
@@ -1195,7 +1200,8 @@ func (s *CrawlerTestSuite) TestCrawlSameReference() {
 		On("Get", mock.Anything, r.Resource.ID, &indexTypes.Update{}, []string{"references", "last-seen"}).
 		Run(func(args mock.Arguments) {
 			u := args.Get(2).(*indexTypes.Update)
-			u.LastSeen = time.Now()
+			lastSeen := time.Now()
+			u.LastSeen = &lastSeen
 			u.References = indexTypes.References{
 				indexTypes.Reference{
 					ParentHash: "QmYAqhbqNDpU7X9VW6FV5imtngQ3oBRY35zuDXduuZnyA8",
@@ -1231,6 +1237,7 @@ func (s *CrawlerTestSuite) TestCrawlSameReferenceDifferentName() {
 			Protocol: t.IPFSProtocol,
 			ID:       "QmSKboVigcD3AY4kLsob117KJcMHvMUu6vNFqk1PQzYUpp",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: &t.Resource{
 				Protocol: t.IPFSProtocol,
@@ -1245,7 +1252,8 @@ func (s *CrawlerTestSuite) TestCrawlSameReferenceDifferentName() {
 		On("Get", mock.Anything, r.Resource.ID, &indexTypes.Update{}, []string{"references", "last-seen"}).
 		Run(func(args mock.Arguments) {
 			u := args.Get(2).(*indexTypes.Update)
-			u.LastSeen = time.Now()
+			lastSeen := time.Now()
+			u.LastSeen = &lastSeen
 			u.References = indexTypes.References{
 				indexTypes.Reference{
 					ParentHash: "QmYAqhbqNDpU7X9VW6FV5imtngQ3oBRY35zuDXduuZnyA8",
@@ -1278,7 +1286,7 @@ func (s *CrawlerTestSuite) TestCrawlSameReferenceDifferentName() {
 					Name:       "NewReference.pdf",
 				},
 			}) &&
-				s.WithinDuration(u.LastSeen, time.Now(), time.Second)
+				u.LastSeen == nil
 		})).
 		Return(nil).
 		Once()

--- a/components/crawler/update.go
+++ b/components/crawler/update.go
@@ -56,6 +56,11 @@ func (c *Crawler) updateExisting(ctx context.Context, i *existingItem) error {
 		// TODO: Remove UnknownSource after sniffer is updated and queue is flushed.
 		// Item sniffed, conditionally update last-seen.
 		now := time.Now()
+
+		// Strip milliseconds to cater to legacy ES index format.
+		// This can be safely removed after the next reindex with _nomillis removed from time format.
+		now = now.Truncate(time.Second)
+
 		isRecent := now.Sub(*i.LastSeen) > c.config.MinUpdateAge
 
 		if isRecent {

--- a/components/crawler/update.go
+++ b/components/crawler/update.go
@@ -69,6 +69,9 @@ func (c *Crawler) updateExisting(ctx context.Context, i *existingItem) error {
 			})
 		}
 
+	case t.ManualSource, t.UserSource:
+		// Do not update based on manual or user input.
+
 	default:
 		// Panic for unexpected Source values, instead of hard failing.
 		panic(fmt.Sprintf("Unexpected source %s for item %+v", i.Source, i))

--- a/components/crawler/update.go
+++ b/components/crawler/update.go
@@ -53,6 +53,7 @@ func (c *Crawler) updateExisting(ctx context.Context, i *existingItem) error {
 		}
 
 	case t.SnifferSource, t.UnknownSource:
+		// TODO: Remove UnknownSource after sniffer is updated and queue is flushed.
 		// Item sniffed, conditionally update last-seen.
 		now := time.Now()
 		isRecent := now.Sub(*i.LastSeen) > c.config.MinUpdateAge

--- a/components/index/types/update.go
+++ b/components/index/types/update.go
@@ -6,6 +6,6 @@ import (
 
 // Update represents the updatable part of a Document.
 type Update struct {
-	LastSeen   time.Time  `json:"last-seen"`
+	LastSeen   *time.Time `json:"last-seen,omitempty"`
 	References References `json:"references,omitempty"`
 }

--- a/components/protocol/ipfs/ls.go
+++ b/components/protocol/ipfs/ls.go
@@ -180,6 +180,7 @@ func (i *IPFS) Ls(ctx context.Context, r *t.AnnotatedResource, out chan<- *t.Ann
 				Protocol: t.IPFSProtocol,
 				ID:       link.Hash,
 			},
+			Source: t.DirectorySource,
 			Reference: t.Reference{
 				Parent: r.Resource,
 				Name:   link.Name,

--- a/components/protocol/ipfs/ls_test.go
+++ b/components/protocol/ipfs/ls_test.go
@@ -104,6 +104,7 @@ func (s *LsTestSuite) TestLsHAMTDirectory() {
 			Protocol: t.IPFSProtocol,
 			ID:       "bafkreidnsi74hf7n2dtidxnqjdyr6lxidnsikdgwxktd7m3duwkuwl2u5u",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: r.Resource,
 			Name:   "Back_of_the_moon.html",
@@ -122,6 +123,7 @@ func (s *LsTestSuite) TestLsHAMTDirectory() {
 			Protocol: t.IPFSProtocol,
 			ID:       "bafkreice7raasrty3makrm3gyg7sjqimdhhx6pdezh2noh3jlzwmvdcooy",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: r.Resource,
 			Name:   "Munchh..html",
@@ -138,6 +140,7 @@ func (s *LsTestSuite) TestLsHAMTDirectory() {
 			Protocol: t.IPFSProtocol,
 			ID:       "bafkreice7raasrty3makrm3gyg7sjqimdhhx6pdezh2noh3jlzwmvdcooy",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: r.Resource,
 			Name:   "directory",
@@ -154,6 +157,7 @@ func (s *LsTestSuite) TestLsHAMTDirectory() {
 			Protocol: t.IPFSProtocol,
 			ID:       "bafkreice7raasrty3makrm3gyg7sjqimdhhx6pdezh2noh3jlzwmvdcooy",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: r.Resource,
 			Name:   "unsupported",
@@ -198,6 +202,7 @@ func (s *LsTestSuite) TestNormalDirectory() {
 			Protocol: t.IPFSProtocol,
 			ID:       "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: r.Resource,
 			Name:   "about",
@@ -216,6 +221,7 @@ func (s *LsTestSuite) TestNormalDirectory() {
 			Protocol: t.IPFSProtocol,
 			ID:       "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
 		},
+		Source: t.DirectorySource,
 		Reference: t.Reference{
 			Parent: r.Resource,
 			Name:   "contact",

--- a/components/sniffer/queuer/queuer.go
+++ b/components/sniffer/queuer/queuer.go
@@ -51,6 +51,7 @@ func (q *Queuer) iterate(ctx context.Context) error {
 
 			r := t.AnnotatedResource{
 				Resource: p.Resource,
+				Source:   t.SnifferSource,
 			}
 
 			// Add with highest priority (9), as this is supposed to be available

--- a/components/sniffer/queuer/queuer.go
+++ b/components/sniffer/queuer/queuer.go
@@ -49,6 +49,8 @@ func (q *Queuer) iterate(ctx context.Context) error {
 			), trace.WithSpanKind(trace.SpanKindProducer))
 			defer span.End()
 
+			// TODO: Queue provider here, not AnnotatedResource.
+
 			r := t.AnnotatedResource{
 				Resource: p.Resource,
 				Source:   t.SnifferSource,

--- a/components/sniffer/queuer/queuer_test.go
+++ b/components/sniffer/queuer/queuer_test.go
@@ -28,6 +28,7 @@ func (s *QueuerTestSuite) SetupTest() {
 	s.p = t.MockProvider()
 	s.r = &t.AnnotatedResource{
 		Resource: s.p.Resource,
+		Source:   t.SnifferSource,
 	}
 }
 

--- a/types/annotatedresource.go
+++ b/types/annotatedresource.go
@@ -7,6 +7,7 @@ import (
 // AnnotatedResource annotates a referenced Resource with additional information.
 type AnnotatedResource struct {
 	*Resource
+	Source    SourceType `json:",omitempty`
 	Reference `json:",omitempty"`
 	Stat      `json:",omitempty"`
 }

--- a/types/sourcetype.go
+++ b/types/sourcetype.go
@@ -10,6 +10,10 @@ const (
 	SnifferSource
 	// DirectorySource represents items sourced from a directory.
 	DirectorySource
+	// ManualSource represents items sourced through (trusted) manual input.
+	ManualSource
+	// UserSource represents items sourced from (untrusted) users.
+	UserSource
 )
 
 func (t SourceType) String() string {
@@ -20,6 +24,10 @@ func (t SourceType) String() string {
 		return "sniffer"
 	case DirectorySource:
 		return "directory"
+	case ManualSource:
+		return "manual"
+	case UserSource:
+		return "user"
 	default:
 		panic("Invalid value for SourceType.")
 	}

--- a/types/sourcetype.go
+++ b/types/sourcetype.go
@@ -1,0 +1,26 @@
+package types
+
+// SourceType is an enum of possible sources for resources.
+type SourceType uint8
+
+const (
+	// UnknownSource represents items for which no source is defined.
+	UnknownSource SourceType = iota
+	// SnifferSource represents items sourced from the sniffer.
+	SnifferSource
+	// DirectorySource represents items sourced from a directory.
+	DirectorySource
+)
+
+func (t SourceType) String() string {
+	switch t {
+	case UnknownSource:
+		return "unknown"
+	case SnifferSource:
+		return "sniffer"
+	case DirectorySource:
+		return "directory"
+	default:
+		panic("Invalid value for SourceType.")
+	}
+}


### PR DESCRIPTION
This should hugely reduce the update rate, and yield more accurate results.