### PR TITLE
Redis fixups

### DIFF
--- a/components/crawler/existingitem.go
+++ b/components/crawler/existingitem.go
@@ -17,7 +17,7 @@ type existingItem struct {
 func (c *Crawler) getExistingItem(ctx context.Context, r *t.AnnotatedResource) (*existingItem, error) {
 	indexes := []index.Index{c.indexes.Files, c.indexes.Directories, c.indexes.Invalids, c.indexes.Partials}
 
-	update := new(index_types.Update)
+	update := &index_types.Update{}
 
 	index, err := index.MultiGet(ctx, indexes, r.ID, update, "references", "last-seen")
 	if err != nil {

--- a/components/crawler/update.go
+++ b/components/crawler/update.go
@@ -65,7 +65,7 @@ func (c *Crawler) updateExisting(ctx context.Context, i *existingItem) error {
 
 		var isRecent bool
 		if i.LastSeen == nil {
-			// No LastSeen set, override isRecent
+			log.Printf("LastSeen is nil, overriding isRecent.")
 			isRecent = true
 		} else {
 			isRecent = now.Sub(*i.LastSeen) > c.config.MinUpdateAge

--- a/components/index/cache/config.go
+++ b/components/index/cache/config.go
@@ -1,5 +1,0 @@
-package cache
-
-// Config for caching index.
-type Config struct {
-}

--- a/components/index/cache/config.go
+++ b/components/index/cache/config.go
@@ -2,5 +2,4 @@ package cache
 
 // Config for caching index.
 type Config struct {
-	CachingFields []string
 }

--- a/components/index/cache/index.go
+++ b/components/index/cache/index.go
@@ -14,7 +14,6 @@ const debug bool = true
 
 // Index wraps a backing index and caches it using another index.
 type Index struct {
-	cfg          *Config
 	backingIndex index.Index
 	cachingIndex index.Index
 	cachingType  reflect.Type
@@ -23,13 +22,7 @@ type Index struct {
 }
 
 // New returns a new index.
-func New(backing index.Index, caching index.Index, cachingType interface{},
-	cfg *Config, instr *instr.Instrumentation) index.Index {
-
-	if cfg == nil {
-		panic("Index.New Config cannot be nil.")
-	}
-
+func New(backing index.Index, caching index.Index, cachingType interface{}, instr *instr.Instrumentation) index.Index {
 	t := reflect.TypeOf(cachingType)
 	if t.Kind() == reflect.Pointer {
 		// Dereference pointer
@@ -44,7 +37,6 @@ func New(backing index.Index, caching index.Index, cachingType interface{},
 		backingIndex:    backing,
 		cachingIndex:    caching,
 		cachingType:     t,
-		cfg:             cfg,
 		Instrumentation: instr,
 	}
 

--- a/components/index/cache/index.go
+++ b/components/index/cache/index.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ipfs-search/ipfs-search/instr"
 )
 
-const debug bool = true
+const debug bool = false
 
 // Index wraps a backing index and caches it using another index.
 type Index struct {
@@ -95,11 +95,10 @@ func (i *Index) makeCachingProperties(props interface{}) interface{} {
 		setFieldVal(src, dst, dstField)
 	}
 
-	if debug {
-		// Note: this dumps excessive amounts of data to the log!
-		// log.Printf("makeCachingProperties - src: %s: %v", src.Type(), src)
-		log.Printf("makeCachingProperties - dst: %s: %v", dst.Type(), dst)
-	}
+	// if debug {
+	// 	log.Printf("makeCachingProperties - src: %s: %v", src.Type(), src)
+	// 	log.Printf("makeCachingProperties - dst: %s: %v", dst.Type(), dst)
+	// }
 
 	return dstPtr.Interface()
 }

--- a/components/index/cache/index_test.go
+++ b/components/index/cache/index_test.go
@@ -25,7 +25,7 @@ type testStruct struct {
 }
 
 type cacheStruct struct {
-	ValOne   string
+	ValOne   *string
 	ValThree float64
 	ValFour  struct {
 		v string
@@ -34,8 +34,10 @@ type cacheStruct struct {
 
 var cachingFields []string = []string{"ValOne", "ValThree", "ValFour", "neverFound"}
 var props = testStruct{"test", 5, 5.5, struct{ v string }{"h"}, 3}
-var cachedProps = cacheStruct{"test", 5.5, struct{ v string }{"h"}}
-var emptyCachedProps = cacheStruct{"", 0.0, struct{ v string }{""}}
+var testStr = "test"
+var emptyStr = ""
+var cachedProps = cacheStruct{&testStr, 5.5, struct{ v string }{"h"}}
+var emptyCachedProps = cacheStruct{&emptyStr, 0.0, struct{ v string }{""}}
 
 var testID = "testID"
 var testErr = errors.New("errr")
@@ -76,7 +78,7 @@ func (s *CacheTestSuite) TestNew() {
 }
 
 func (s *CacheTestSuite) TestString() {
-	exp := fmt.Sprintf("cache for '%s' through '%s'", s.backingIndex, s.cachingIndex)
+	exp := fmt.Sprintf("'%s' through '%s'", s.backingIndex, s.cachingIndex)
 	s.Equal(exp, s.i.String())
 }
 
@@ -87,10 +89,10 @@ func (s *CacheTestSuite) TestMakeCachingProperties() {
 
 	s.IsType(res, &cacheStruct{})
 
-	casres := res.(*cacheStruct)
-	s.Equal(props.ValOne, casres.ValOne)
-	s.Equal(props.ValThree, casres.ValThree)
-	s.Equal(props.ValFour, casres.ValFour)
+	cacheres := res.(*cacheStruct)
+	s.Equal(props.ValOne, *cacheres.ValOne)
+	s.Equal(props.ValThree, cacheres.ValThree)
+	s.Equal(props.ValFour, cacheres.ValFour)
 }
 
 func (s *CacheTestSuite) TestIndexSuccess() {

--- a/components/index/cache/index_test.go
+++ b/components/index/cache/index_test.go
@@ -69,11 +69,11 @@ func (s *CacheTestSuite) SetupTest() {
 
 func (s *CacheTestSuite) TestNew() {
 	// Allow value.
-	i := New(s.backingIndex, s.cachingIndex, cacheStruct{}, &Config{}, s.instr)
+	i := New(s.backingIndex, s.cachingIndex, cacheStruct{}, s.instr)
 	s.NotNil(i)
 
 	// Allow pointer as well.
-	i = New(s.backingIndex, s.cachingIndex, &cacheStruct{}, &Config{}, s.instr)
+	i = New(s.backingIndex, s.cachingIndex, &cacheStruct{}, s.instr)
 	s.NotNil(i)
 }
 

--- a/components/index/cache/reflect.go
+++ b/components/index/cache/reflect.go
@@ -1,0 +1,26 @@
+package cache
+
+import (
+	"reflect"
+)
+
+// GetStructElem expects an interface containing a pointer to a struct and returns the value thereof.
+func GetStructElem(s interface{}) reflect.Value {
+	// Source value
+	src := reflect.ValueOf(s)
+
+	// Ensure src is a pointer pointer
+	if src.Kind() != reflect.Pointer {
+		panic("not called with pointer")
+	}
+
+	// Dereference src
+	src = src.Elem()
+
+	// Ensure src is a struct
+	if src.Kind() != reflect.Struct {
+		panic("not struct pointer")
+	}
+
+	return src
+}

--- a/components/index/opensearch/client.go
+++ b/components/index/opensearch/client.go
@@ -12,6 +12,7 @@ import (
 	opensearchutil "github.com/opensearch-project/opensearch-go/v2/opensearchutil"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/ipfs-search/ipfs-search/components/index"
 	"github.com/ipfs-search/ipfs-search/components/index/opensearch/bulkgetter"
 	"github.com/ipfs-search/ipfs-search/instr"
 )
@@ -82,6 +83,14 @@ func (c *Client) Work(ctx context.Context) error {
 	defer c.bulkIndexer.Close(context.Background())
 
 	return c.bulkGetter.Work(ctx)
+}
+
+// NewIndex returns a new index given with given name.
+func (c *Client) NewIndex(name string) index.Index {
+	return New(
+		c,
+		&Config{Name: name},
+	)
 }
 
 func getSearchClient(cfg *ClientConfig, i *instr.Instrumentation) (*opensearch.Client, error) {

--- a/components/index/opensearch/index.go
+++ b/components/index/opensearch/index.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ipfs-search/ipfs-search/components/index/opensearch/bulkgetter"
 )
 
-const debug bool = true
+const debug bool = false
 
 // Index wraps an OpenSearch index to store documents
 type Index struct {

--- a/components/index/opensearch/index.go
+++ b/components/index/opensearch/index.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ipfs-search/ipfs-search/components/index/opensearch/bulkgetter"
 )
 
-const debug bool = false
+const debug bool = true
 
 // Index wraps an OpenSearch index to store documents
 type Index struct {

--- a/components/index/redis/client.go
+++ b/components/index/redis/client.go
@@ -7,6 +7,7 @@ import (
 
 	radix "github.com/mediocregopher/radix/v4"
 
+	"github.com/ipfs-search/ipfs-search/components/index"
 	"github.com/ipfs-search/ipfs-search/instr"
 )
 
@@ -72,6 +73,21 @@ func (c *Client) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// NewIndex returns a new index given with given name and prefix. When existsIndex is true, an ExistsIndex will be returned.
+func (c *Client) NewIndex(name, prefix string, existsIndex bool) index.Index {
+	if existsIndex {
+		return NewExistsIndex(
+			c,
+			&Config{Name: name, Prefix: prefix},
+		)
+	}
+
+	return New(
+		c,
+		&Config{Name: name, Prefix: prefix},
+	)
 }
 
 // Close closes the Redis client connection.

--- a/components/index/redis/config.go
+++ b/components/index/redis/config.go
@@ -2,5 +2,6 @@ package redis
 
 // Config holds configuration for a Redis index.
 type Config struct {
-	Name string // Name of the index.
+	Name   string // Name of the index.
+	Prefix string // Key prefix.
 }

--- a/components/index/redis/existsindex.go
+++ b/components/index/redis/existsindex.go
@@ -1,0 +1,99 @@
+package redis
+
+import (
+	"context"
+	"log"
+
+	"github.com/ipfs-search/ipfs-search/components/index"
+
+	radix "github.com/mediocregopher/radix/v4"
+)
+
+// ExistsIndex stores properties as JSON in Redis.
+type ExistsIndex struct {
+	cfg *Config
+	c   *Client
+	key string
+}
+
+// NewExistsIndex returns a new index.
+func NewExistsIndex(client *Client, cfg *Config) index.Index {
+	if client == nil {
+		panic("NewExistsIndex Client cannot be nil.")
+	}
+
+	if cfg == nil {
+		panic("NewExistsIndex Config cannot be nil.")
+	}
+
+	index := &ExistsIndex{
+		c:   client,
+		cfg: cfg,
+		key: client.cfg.Prefix + "e:" + cfg.Prefix,
+	}
+
+	return index
+}
+
+func (i *ExistsIndex) set(ctx context.Context, id string, properties interface{}) error {
+	if debug {
+		log.Printf("redis exists %s: add %s to %s", i, id, i.key)
+	}
+
+	action := radix.Cmd(nil, "SADD", i.key, id)
+	return i.c.radixClient.Do(ctx, action)
+}
+
+// String returns the name of the index, for convenient logging.
+func (i *ExistsIndex) String() string {
+	return i.cfg.Name
+}
+
+// Index a document's properties, identified by id
+func (i *ExistsIndex) Index(ctx context.Context, id string, properties interface{}) error {
+	ctx, span := i.c.Tracer.Start(ctx, "index.redis.Index")
+	defer span.End()
+
+	return i.set(ctx, id, properties)
+}
+
+// Update a document's properties, given id
+func (i *ExistsIndex) Update(ctx context.Context, id string, properties interface{}) error {
+	ctx, span := i.c.Tracer.Start(ctx, "index.redis.Update")
+	defer span.End()
+
+	return i.set(ctx, id, properties)
+}
+
+// Delete item from set.
+func (i *ExistsIndex) Delete(ctx context.Context, id string) error {
+	ctx, span := i.c.Tracer.Start(ctx, "index.redis.Delete")
+	defer span.End()
+
+	if debug {
+		log.Printf("redis exists %s: delete %s from %s", i, id, i.key)
+	}
+
+	// Non-blocking DEL-equivalent
+	action := radix.Cmd(nil, "SREM", i.key, id)
+	return i.c.radixClient.Do(ctx, action)
+}
+
+// Get returns whether or not an item is found (but doesn't update its properties).
+func (i *ExistsIndex) Get(ctx context.Context, id string, dst interface{}, fields ...string) (bool, error) {
+	ctx, span := i.c.Tracer.Start(ctx, "index.redis.Get")
+	defer span.End()
+
+	var found bool
+	action := radix.Cmd(&found, "SISMEMBER", i.key, id)
+	err := i.c.radixClient.Do(ctx, action)
+
+	if debug {
+		log.Printf("redis exists %s: get %s from %s, res: %v", i, id, i.key, found)
+	}
+
+	return found, err
+}
+
+// Compile-time assurance that implementation satisfies interface.
+var _ index.Index = &ExistsIndex{}

--- a/components/index/redis/existsindex.go
+++ b/components/index/redis/existsindex.go
@@ -89,7 +89,7 @@ func (i *ExistsIndex) Get(ctx context.Context, id string, dst interface{}, field
 	err := i.c.radixClient.Do(ctx, action)
 
 	if debug {
-		log.Printf("redis exists %s: get %s from %s, res: %v", i, id, i.key, found)
+		log.Printf("redis exists %s: get %s from %s, res: %v, err: %v", i, id, i.key, found, err)
 	}
 
 	return found, err

--- a/components/index/redis/exitsindex_test.go
+++ b/components/index/redis/exitsindex_test.go
@@ -14,21 +14,15 @@ import (
 	"github.com/ipfs-search/ipfs-search/instr"
 )
 
-const indexName = "indexName"
-const indexPrefix = "indexPrefix"
-const testId = "testId"
-
-type RedisTestSuite struct {
+type ExistsIndexTestSuite struct {
 	suite.Suite
 	ctx   context.Context
 	instr *instr.Instrumentation
 
-	i *Index
+	i *ExistsIndex
 }
 
-type stubFunc func(context.Context, []string) interface{}
-
-func (s *RedisTestSuite) stubClient(fn stubFunc) *Client {
+func (s *ExistsIndexTestSuite) stubClient(fn stubFunc) *Client {
 	conn := radix.NewStubConn("", "", fn)
 	rClient := radix.NewMultiClient(radix.ReplicaSet{
 		Primary: conn,
@@ -40,7 +34,7 @@ func (s *RedisTestSuite) stubClient(fn stubFunc) *Client {
 	}
 }
 
-func (s *RedisTestSuite) stubIndex(fn stubFunc) *Index {
+func (s *ExistsIndexTestSuite) stubIndex(fn stubFunc) *Index {
 	client := s.stubClient(fn)
 	cfg := &Config{
 		Name:   indexName,
@@ -52,11 +46,11 @@ func (s *RedisTestSuite) stubIndex(fn stubFunc) *Index {
 	}
 }
 
-func (s *RedisTestSuite) SetupTest() {
+func (s *ExistsIndexTestSuite) SetupTest() {
 	s.ctx = context.Background()
 }
 
-func (s *RedisTestSuite) TestGetKey() {
+func (s *ExistsIndexTestSuite) TestGetKey() {
 	i := s.stubIndex(func(_ context.Context, _ []string) interface{} {
 		return nil
 	})
@@ -65,7 +59,7 @@ func (s *RedisTestSuite) TestGetKey() {
 	s.Equal(indexPrefix+":"+testId, k)
 }
 
-func (s *RedisTestSuite) TestSetLastSeenOnly() {
+func (s *ExistsIndexTestSuite) TestSetLastSeenOnly() {
 	now := time.Now().Truncate(time.Second)
 	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
 		s.Len(args, 4)
@@ -84,7 +78,7 @@ func (s *RedisTestSuite) TestSetLastSeenOnly() {
 	s.NoError(err)
 }
 
-func (s *RedisTestSuite) TestSetReferencesOnly() {
+func (s *ExistsIndexTestSuite) TestSetReferencesOnly() {
 	r1 := types.Reference{
 		ParentHash: "p1",
 		Name:       "f1",
@@ -119,7 +113,7 @@ func (s *RedisTestSuite) TestSetReferencesOnly() {
 	s.NoError(err)
 }
 
-// func (s *RedisTestSuite) TestEmpty() {
+// func (s *ExistsIndexTestSuite) TestEmpty() {
 // 	u := &types.Update{}
 
 // 	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
@@ -135,7 +129,7 @@ func (s *RedisTestSuite) TestSetReferencesOnly() {
 // 	s.NoError(err)
 // }
 
-func (s *RedisTestSuite) TestSetAll() {
+func (s *ExistsIndexTestSuite) TestSetAll() {
 	now := time.Now().Truncate(time.Second)
 
 	r1 := types.Reference{
@@ -173,7 +167,7 @@ func (s *RedisTestSuite) TestSetAll() {
 	s.NoError(err)
 }
 
-func (s *RedisTestSuite) TestString() {
+func (s *ExistsIndexTestSuite) TestString() {
 	i := s.stubIndex(func(_ context.Context, _ []string) interface{} {
 		return nil
 	})
@@ -183,10 +177,10 @@ func (s *RedisTestSuite) TestString() {
 }
 
 // Identical to set
-// func (s *RedisTestSuite) TestIndex() {}
-// func (s *RedisTestSuite) TestUpdate() {}
+// func (s *ExistsIndexTestSuite) TestIndex() {}
+// func (s *ExistsIndexTestSuite) TestUpdate() {}
 
-func (s *RedisTestSuite) TestDelete() {
+func (s *ExistsIndexTestSuite) TestDelete() {
 	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
 		s.Len(args, 2)
 		s.Equal("UNLINK", args[0])
@@ -197,7 +191,7 @@ func (s *RedisTestSuite) TestDelete() {
 	s.NoError(err)
 }
 
-func (s *RedisTestSuite) TestGetFound() {
+func (s *ExistsIndexTestSuite) TestGetFound() {
 	now := time.Now().Truncate(time.Second)
 	nBytes, _ := now.MarshalText()
 
@@ -236,7 +230,7 @@ func (s *RedisTestSuite) TestGetFound() {
 	s.Equal(u, dst)
 }
 
-func (s *RedisTestSuite) TestGetNotFound() {
+func (s *ExistsIndexTestSuite) TestGetNotFound() {
 	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
 		s.Len(args, 2)
 		s.Equal("HGETALL", args[0])
@@ -252,7 +246,7 @@ func (s *RedisTestSuite) TestGetNotFound() {
 	s.False(found)
 }
 
-func (s *RedisTestSuite) TestError() {
+func (s *ExistsIndexTestSuite) TestError() {
 	testErr := errors.New("error")
 	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
 		return testErr
@@ -266,6 +260,6 @@ func (s *RedisTestSuite) TestError() {
 	s.Equal(testErr, err)
 }
 
-func TestRedisTestSuite(t *testing.T) {
-	suite.Run(t, new(RedisTestSuite))
+func TestExistsIndexTestSuite(t *testing.T) {
+	suite.Run(t, new(ExistsIndexTestSuite))
 }

--- a/components/index/redis/index.go
+++ b/components/index/redis/index.go
@@ -21,11 +21,19 @@ type Index struct {
 // New returns a new index.
 func New(client *Client, cfg *Config) index.Index {
 	if client == nil {
-		panic("Index.New Client cannot be nil.")
+		panic("client cannot be nil")
 	}
 
 	if cfg == nil {
-		panic("Index.New Config cannot be nil.")
+		panic("cfg cannot be nil")
+	}
+
+	if cfg.Name == "" {
+		panic("Name cannot be empty")
+	}
+
+	if cfg.Prefix == "" {
+		panic("Prefix cannot be empty")
 	}
 
 	index := &Index{

--- a/components/index/redis/index.go
+++ b/components/index/redis/index.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mediocregopher/radix/v4/resp/resp3"
 )
 
-const debug bool = true
+const debug bool = false
 
 // Index stores properties as JSON in Redis.
 type Index struct {
@@ -62,7 +62,7 @@ func (i *Index) set(ctx context.Context, id string, properties interface{}) erro
 	}
 
 	if debug {
-		log.Printf("redis %s: writing %+v to %s", i, flattened, key)
+		log.Printf("redis %s: writing to %s", i, key)
 	}
 
 	args = append(args, flattened...)
@@ -125,13 +125,12 @@ func (i *Index) Get(ctx context.Context, id string, dst interface{}, fields ...s
 	action := radix.Cmd(mb, "HGETALL", key)
 	err := i.c.radixClient.Do(ctx, action)
 
-	// if debug {
-	// 	log.Printf("redis %s: get %s", i, key)
-	// 	log.Printf("redis %s: maybe: %+v", i, mb)
-	// 	log.Printf("redis %s: dst: %T: %v", i, dst, dst)
-	// }
+	found := !(mb.Null || mb.Empty)
+	if debug {
+		log.Printf("redis %s: get %s from %s, res: %v, err: %v", i, id, key, found, err)
+	}
 
-	return !(mb.Null || mb.Empty || err != nil), err
+	return err == nil && found, err
 }
 
 // Compile-time assurance that implementation satisfies interface.

--- a/components/index/redis/index.go
+++ b/components/index/redis/index.go
@@ -50,8 +50,7 @@ func (i *Index) set(ctx context.Context, id string, properties interface{}) erro
 	}
 
 	if len(flattened) == 0 {
-		// Existence only, use bogus value
-		flattened = []string{"0", "0"}
+		panic("Redis cannot index without properties.")
 	}
 
 	if debug {

--- a/components/index/redis/index.go
+++ b/components/index/redis/index.go
@@ -37,7 +37,7 @@ func New(client *Client, cfg *Config) index.Index {
 }
 
 func (i *Index) getKey(key string) string {
-	return i.c.cfg.Prefix + i.cfg.Name + ":" + key
+	return i.c.cfg.Prefix + i.cfg.Prefix + ":" + key
 }
 
 func (i *Index) set(ctx context.Context, id string, properties interface{}) error {

--- a/components/index/redis/index_test.go
+++ b/components/index/redis/index_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 const indexName = "indexName"
+const indexPrefix = "indexPrefix"
 const testId = "testId"
 
 type RedisTestSuite struct {
@@ -42,7 +43,8 @@ func (s *RedisTestSuite) stubClient(fn stubFunc) *Client {
 func (s *RedisTestSuite) stubIndex(fn stubFunc) *Index {
 	client := s.stubClient(fn)
 	cfg := &Config{
-		Name: indexName,
+		Name:   indexName,
+		Prefix: indexPrefix,
 	}
 
 	return &Index{
@@ -60,7 +62,7 @@ func (s *RedisTestSuite) TestGetKey() {
 	})
 
 	k := i.getKey(testId)
-	s.Equal(indexName+":"+testId, k)
+	s.Equal(indexPrefix+":"+testId, k)
 }
 
 func (s *RedisTestSuite) TestSetLastSeenOnly() {

--- a/components/index/redis/index_test.go
+++ b/components/index/redis/index_test.go
@@ -2,13 +2,20 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/mock"
+	// "github.com/stretchr/testify/mock"
+	radix "github.com/mediocregopher/radix/v4"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/ipfs-search/ipfs-search/components/index/types"
 	"github.com/ipfs-search/ipfs-search/instr"
 )
+
+const indexName = "indexName"
+const testId = "testId"
 
 type RedisTestSuite struct {
 	suite.Suite
@@ -18,45 +25,227 @@ type RedisTestSuite struct {
 	i *Index
 }
 
-type rueidisMock struct {
-	mock.Mock
+type stubFunc func(context.Context, []string) interface{}
+
+func (s *RedisTestSuite) stubClient(fn stubFunc) *Client {
+	conn := radix.NewStubConn("", "", fn)
+	rClient := radix.NewMultiClient(radix.ReplicaSet{
+		Primary: conn,
+	})
+	return &Client{
+		cfg:             &ClientConfig{},
+		Instrumentation: instr.New(),
+		radixClient:     rClient,
+	}
+}
+
+func (s *RedisTestSuite) stubIndex(fn stubFunc) *Index {
+	client := s.stubClient(fn)
+	cfg := &Config{
+		Name: indexName,
+	}
+
+	return &Index{
+		cfg, client,
+	}
 }
 
 func (s *RedisTestSuite) SetupTest() {
-
+	s.ctx = context.Background()
 }
 
 func (s *RedisTestSuite) TestGetKey() {
+	i := s.stubIndex(func(_ context.Context, _ []string) interface{} {
+		return nil
+	})
 
+	k := i.getKey(testId)
+	s.Equal(indexName+":"+testId, k)
 }
 
-func (s *RedisTestSuite) TestSet() {
+func (s *RedisTestSuite) TestSetLastSeenOnly() {
+	now := time.Now().Truncate(time.Second)
+	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
+		s.Len(args, 4)
+		s.Equal("HSET", args[0])
+		// We test key generation elsewhere, ignore args[1]
+		s.Equal("l", args[2]) // Use the `redis` tag.
+		s.Equal(now.Format(time.RFC3339), args[3])
 
+		return nil
+	})
+	u := &types.Update{
+		LastSeen: &now,
+	}
+
+	err := i.set(s.ctx, testId, u)
+	s.NoError(err)
+}
+
+func (s *RedisTestSuite) TestSetReferencesOnly() {
+	r1 := types.Reference{
+		ParentHash: "p1",
+		Name:       "f1",
+	}
+	r2 := types.Reference{
+		ParentHash: "p2",
+		Name:       "f2",
+	}
+	r := types.References{
+		r1, r2,
+	}
+	u := &types.Update{
+		References: r,
+	}
+
+	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
+		s.Len(args, 4)
+		s.Equal("HSET", args[0])
+		// We test key generation elsewhere, ignore args[1]
+		s.Equal("r", args[2]) // Use the `redis` tag.
+
+		refs := types.References{}
+		err := refs.UnmarshalBinary([]byte(args[3]))
+		s.NoError(err)
+
+		s.Equal(refs, u.References)
+
+		return nil
+	})
+
+	err := i.set(s.ctx, testId, u)
+	s.NoError(err)
+}
+
+func (s *RedisTestSuite) TestSetAll() {
+	now := time.Now().Truncate(time.Second)
+
+	r1 := types.Reference{
+		ParentHash: "p1",
+		Name:       "f1",
+	}
+	r := types.References{
+		r1,
+	}
+	u := &types.Update{
+		LastSeen:   &now,
+		References: r,
+	}
+
+	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
+		s.Len(args, 6)
+		s.Equal("HSET", args[0])
+		// We test key generation elsewhere, ignore args[1]
+
+		s.Equal("l", args[2]) // Use the `redis` tag.
+		s.Equal(now.Format(time.RFC3339), args[3])
+
+		s.Equal("r", args[4]) // Use the `redis` tag.
+
+		refs := types.References{}
+		err := refs.UnmarshalBinary([]byte(args[5]))
+		s.NoError(err)
+
+		s.Equal(refs, u.References)
+
+		return nil
+	})
+
+	err := i.set(s.ctx, testId, u)
+	s.NoError(err)
 }
 
 func (s *RedisTestSuite) TestString() {
+	i := s.stubIndex(func(_ context.Context, _ []string) interface{} {
+		return nil
+	})
 
+	str := i.String()
+	s.Equal(indexName, str)
 }
 
-func (s *RedisTestSuite) TestIndex() {
-
-}
-
-func (s *RedisTestSuite) TestUpdate() {
-
-}
+// Identical to set
+// func (s *RedisTestSuite) TestIndex() {}
+// func (s *RedisTestSuite) TestUpdate() {}
 
 func (s *RedisTestSuite) TestDelete() {
-
+	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
+		s.Len(args, 2)
+		s.Equal("UNLINK", args[0])
+		// We test key generation elsewhere, ignore args[1]
+		return nil
+	})
+	err := i.Delete(s.ctx, testId)
+	s.NoError(err)
 }
 
-func (s *RedisTestSuite) TestGet() {
+func (s *RedisTestSuite) TestGetFound() {
+	now := time.Now().Truncate(time.Second)
+	nBytes, _ := now.MarshalText()
 
+	r1 := types.Reference{
+		ParentHash: "p1",
+		Name:       "f1",
+	}
+	r := types.References{
+		r1,
+	}
+	rBytes, _ := r.MarshalBinary()
+
+	u := &types.Update{
+		LastSeen:   &now,
+		References: r,
+	}
+
+	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
+		s.Len(args, 2)
+		s.Equal("HGETALL", args[0])
+
+		// return []string{"l", string(nBytes)}
+
+		return [][]byte{
+			{'l'}, nBytes,
+			{'r'}, rBytes,
+		}
+	})
+
+	dst := &types.Update{}
+
+	found, err := i.Get(s.ctx, testId, dst)
+	s.NoError(err)
+	s.True(found)
+
+	s.Equal(u, dst)
 }
 
-func (s *RedisTestSuite) AfterTest() {
-	// s.cachingIndex.AssertExpectations(s.T())
-	// s.backingIndex.AssertExpectations(s.T())
+func (s *RedisTestSuite) TestGetNotFound() {
+	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
+		s.Len(args, 2)
+		s.Equal("HGETALL", args[0])
+
+		// Return empty list when key does not exist.
+		return []string{}
+	})
+
+	dst := &types.Update{}
+
+	found, err := i.Get(s.ctx, testId, dst)
+	s.NoError(err)
+	s.False(found)
+}
+
+func (s *RedisTestSuite) TestError() {
+	testErr := errors.New("error")
+	i := s.stubIndex(func(_ context.Context, args []string) interface{} {
+		return testErr
+	})
+
+	dst := &types.Update{}
+
+	found, err := i.Get(s.ctx, testId, dst)
+	s.Error(err)
+	s.False(found)
+	s.Equal(testErr, err)
 }
 
 func TestRedisTestSuite(t *testing.T) {

--- a/components/index/types/document.go
+++ b/components/index/types/document.go
@@ -4,15 +4,6 @@ import (
 	"time"
 )
 
-// Reference represents a named reference to a Document.
-type Reference struct {
-	ParentHash string `json:"parent_hash"`
-	Name       string `json:"name"`
-}
-
-// References is a collection of references to a Document.
-type References []Reference
-
 // Document represents a common properties of resources in an Index.
 type Document struct {
 	FirstSeen  time.Time  `json:"first-seen"`

--- a/components/index/types/references.go
+++ b/components/index/types/references.go
@@ -17,7 +17,7 @@ type Reference struct {
 // References is a collection of references to a Document.
 type References []Reference
 
-// MarshallBinary marshalls into BSON and compresses it.
+// MarshalBinary marshalls into LZ4 compressed BSON.
 func (r References) MarshalBinary() ([]byte, error) {
 	data, err := cbor.Marshal([]Reference(r))
 	if err != nil {
@@ -36,7 +36,7 @@ func (r References) MarshalBinary() ([]byte, error) {
 	return compressed.Bytes(), nil
 }
 
-// MarshallBinary unmarshalls from BSON and compresses it.
+// UnmarshalBinary unmarshalls from LZ4 compressed BSON.
 func (r *References) UnmarshalBinary(data []byte) error {
 	compressed := bytes.NewBuffer(data)
 	uncompressed := new(bytes.Buffer)

--- a/components/index/types/references.go
+++ b/components/index/types/references.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"bytes"
+
+	cbor "github.com/fxamacker/cbor/v2"
+	lz4 "github.com/pierrec/lz4/v4"
+)
+
+// Reference represents a named reference to a Document.
+type Reference struct {
+	_          struct{} `cbor:",toarray"`
+	ParentHash string   `json:"parent_hash"`
+	Name       string   `json:"name"`
+}
+
+// References is a collection of references to a Document.
+type References []Reference
+
+// MarshallBinary marshalls into BSON and compresses it.
+func (r References) MarshalBinary() ([]byte, error) {
+	data, err := cbor.Marshal([]Reference(r))
+	if err != nil {
+		return nil, err
+	}
+
+	compressed := new(bytes.Buffer)
+	writer := lz4.NewWriter(compressed)
+	if _, err := writer.Write(data); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	return compressed.Bytes(), nil
+}
+
+// MarshallBinary unmarshalls from BSON and compresses it.
+func (r *References) UnmarshalBinary(data []byte) error {
+	compressed := bytes.NewBuffer(data)
+	uncompressed := new(bytes.Buffer)
+
+	reader := lz4.NewReader(compressed)
+	if _, err := reader.WriteTo(uncompressed); err != nil {
+		return err
+	}
+
+	return cbor.Unmarshal(uncompressed.Bytes(), r)
+}

--- a/components/index/types/references_test.go
+++ b/components/index/types/references_test.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"log"
+	"testing"
+
+	cbor "github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/suite"
+)
+
+var testRefs References = References{
+	Reference{
+		ParentHash: "QmSKboVigcD3AY4kLsob117KJcMHvMUu6vNFqk1PQzYUpp",
+		Name:       "reference1",
+	},
+	Reference{
+		ParentHash: "QmafrLBfzRLV4XSH1XcaMMeaXEUhDJjmtDfsYU95TrWG87",
+		Name:       "reference2",
+	},
+	Reference{
+		ParentHash: "sdfsdfsdfsd",
+		Name:       "thrd",
+	},
+	Reference{
+		ParentHash: "sdfsdfsdfsd",
+		Name:       "thrd",
+	},
+	Reference{
+		ParentHash: "sdfsdfsdfsd",
+		Name:       "thrd",
+	},
+	Reference{
+		ParentHash: "sdfsdfsdfsd",
+		Name:       "thrd",
+	},
+}
+
+type ReferencesTestSuite struct {
+	suite.Suite
+}
+
+func (s *ReferencesTestSuite) TestMarshallUnmarshallBinary() {
+	data, err := testRefs.MarshalBinary()
+	s.NoError(err)
+	s.NotEmpty(data)
+
+	log.Printf("References serialised to %d bytes", len(data))
+
+	// Check if we can back our original data
+	newRefs := References{}
+	err = newRefs.UnmarshalBinary(data)
+	s.NoError(err)
+
+	s.Equal(testRefs, newRefs)
+
+	// Look at the raw stuff
+	raw := new(interface{})
+	err = cbor.Unmarshal(data, raw)
+	s.NoError(err)
+
+	log.Printf("%v", *raw)
+
+	// json, err := json.MarshalIndent(raw, "", "  ")
+	// s.NoError(err)
+	// log.Printf("%s", json)
+}
+
+func TestReferencesTestSuite(t *testing.T) {
+	suite.Run(t, new(ReferencesTestSuite))
+}

--- a/components/index/types/update.go
+++ b/components/index/types/update.go
@@ -6,6 +6,6 @@ import (
 
 // Update represents the updatable part of a Document.
 type Update struct {
-	LastSeen   *time.Time `json:"last-seen,omitempty"`
-	References References `json:"references,omitempty"`
+	LastSeen   *time.Time `json:"last-seen,omitempty" redis:"l,omitempty"`
+	References References `json:"references,omitempty" redis:"r,omitempty"`
 }

--- a/components/worker/pool/getindexes.go
+++ b/components/worker/pool/getindexes.go
@@ -88,7 +88,7 @@ func (f *indexFactory) getIndex(name string) index.Index {
 		&redis.Config{Name: name},
 	)
 
-	return cache.New(osIndex, redisIndex, f.cacheCfg, f.Instrumentation)
+	return cache.New(osIndex, redisIndex, indexTypes.Update{}, f.cacheCfg, f.Instrumentation)
 }
 
 func (w *Pool) getIndexes(ctx context.Context) (*crawler.Indexes, error) {
@@ -105,9 +105,7 @@ func (w *Pool) getIndexes(ctx context.Context) (*crawler.Indexes, error) {
 	go ensureRedisClose(ctx, redisClient)
 	go startOpenSearchWorker(ctx, osClient)
 
-	cacheCfg := &cache.Config{
-		CachingFields: getCachingFields(),
-	}
+	cacheCfg := &cache.Config{}
 
 	iFactory := indexFactory{
 		osClient, redisClient, cacheCfg, w.Instrumentation,

--- a/components/worker/pool/getindexes.go
+++ b/components/worker/pool/getindexes.go
@@ -83,8 +83,6 @@ func (w *Pool) getIndexes(ctx context.Context) (*crawler.Indexes, error) {
 		redisClient.Close(ctx)
 	}()
 
-	cacheCfg := &cache.Config{}
-
 	return &crawler.Indexes{
 		Files: cache.New(opensearch.New(
 			osClient,
@@ -92,27 +90,27 @@ func (w *Pool) getIndexes(ctx context.Context) (*crawler.Indexes, error) {
 		), redis.New(
 			redisClient,
 			&redis.Config{Name: w.config.Indexes.Files.Name, Prefix: w.config.Indexes.Files.Prefix},
-		), indexTypes.Update{}, cacheCfg, w.Instrumentation),
+		), indexTypes.Update{}, w.Instrumentation),
 		Directories: cache.New(opensearch.New(
 			osClient,
 			&opensearch.Config{Name: w.config.Indexes.Directories.Name},
 		), redis.New(
 			redisClient,
 			&redis.Config{Name: w.config.Indexes.Directories.Name, Prefix: w.config.Indexes.Directories.Prefix},
-		), indexTypes.Update{}, cacheCfg, w.Instrumentation),
+		), indexTypes.Update{}, w.Instrumentation),
 		Invalids: cache.New(opensearch.New(
 			osClient,
 			&opensearch.Config{Name: w.config.Indexes.Invalids.Name},
 		), redis.NewExistsIndex(
 			redisClient,
 			&redis.Config{Name: w.config.Indexes.Invalids.Name, Prefix: w.config.Indexes.Invalids.Prefix},
-		), struct{}{}, cacheCfg, w.Instrumentation),
+		), struct{}{}, w.Instrumentation),
 		Partials: cache.New(opensearch.New(
 			osClient,
 			&opensearch.Config{Name: w.config.Indexes.Partials.Name},
 		), redis.NewExistsIndex(
 			redisClient,
 			&redis.Config{Name: w.config.Indexes.Partials.Name, Prefix: w.config.Indexes.Partials.Prefix},
-		), struct{}{}, cacheCfg, w.Instrumentation),
+		), struct{}{}, w.Instrumentation),
 	}, nil
 }

--- a/config/indexes.go
+++ b/config/indexes.go
@@ -2,7 +2,8 @@ package config
 
 // Index represents the configuration for a single Index.
 type Index struct {
-	Name string
+	Name   string
+	Prefix string
 }
 
 // Indexes represents the various indexes we're using
@@ -17,16 +18,20 @@ type Indexes struct {
 func IndexesDefaults() Indexes {
 	return Indexes{
 		Files: Index{
-			Name: "ipfs_files",
+			Name:   "ipfs_files",
+			Prefix: "f",
 		},
 		Directories: Index{
-			Name: "ipfs_directories",
+			Name:   "ipfs_directories",
+			Prefix: "d",
 		},
 		Invalids: Index{
-			Name: "ipfs_invalids",
+			Name:   "ipfs_invalids",
+			Prefix: "i",
 		},
 		Partials: Index{
-			Name: "ipfs_partials",
+			Name:   "ipfs_partials",
+			Prefix: "p",
 		},
 	}
 }

--- a/docs/default_config.yml
+++ b/docs/default_config.yml
@@ -41,12 +41,16 @@ sniffer:
 indexes:
     files:
         name: ipfs_files
+        prefix: f
     directories:
         name: ipfs_directories
+        prefix: d
     invalids:
         name: ipfs_invalids
+        prefix: i
     partials:
         name: ipfs_partials
+        prefix: p
 queues:
     files:
         name: files

--- a/docs/example_config.yml
+++ b/docs/example_config.yml
@@ -39,11 +39,17 @@ sniffer:
   buffer_size: 512                                    # Size of the channels buffering between yielder, filter and adder
 indexes:
   files:
-    name: ipfs_files                                  # Name of ES index to use.
+    name: ipfs_files                                  # Name of index to use, internally as well as in OpenSearch.
+    prefix: f                                         # Key prefix for Redis cache.
   directories:
     name: ipfs_directories
+    prefix: d
   invalids:
     name: ipfs_invalids
+    prefix: i
+  partials:
+    name: ipfs_partials
+    prefix: p
 queues:
   files:
     name: files                                       # Name of RabbitMQ queue to use.

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/libp2p/go-eventbus v0.2.1
 	github.com/libp2p/go-libp2p-core v0.6.1
 	github.com/libp2p/go-libp2p-kad-dht v0.10.0
+	github.com/mediocregopher/radix/v4 v4.1.1
 	github.com/multiformats/go-base32 v0.0.3
 	github.com/opensearch-project/opensearch-go/v2 v2.0.0
 	github.com/rabbitmq/amqp091-go v1.3.4
-	github.com/rueian/rueidis v0.0.77
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.0
 	go.opentelemetry.io/otel v1.10.0
@@ -76,6 +76,7 @@ require (
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
+	github.com/tilinna/clock v1.0.2 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.22.4 // indirect
@@ -84,6 +85,7 @@ require (
 	go.uber.org/multierr v1.5.0 // indirect
 	go.uber.org/zap v1.15.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/net v0.0.0-20220630215102-69896b714898 // indirect
 	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )
@@ -92,3 +94,5 @@ replace github.com/stretchr/testify => github.com/ipfs-search/testify v1.8.1-0.2
 
 // +heroku goVersion go1.19
 go 1.19
+
+replace github.com/mediocregopher/radix/v4 => github.com/ipfs-search/radix/v4 v4.1.2-0.20221011201541-285efc40920c

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
@@ -69,12 +70,14 @@ require (
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.22.4 // indirect
 	go.opentelemetry.io/otel/metric v0.32.0 // indirect
 	go.uber.org/atomic v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,10 @@ github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs-search/go-env v0.0.0-20220928152343-588b5d46eac9 h1:1qdqVhB47s1Nu/eKvvrhoAaa2w0BU9bzncErsk45ehI=
 github.com/ipfs-search/go-env v0.0.0-20220928152343-588b5d46eac9/go.mod h1:LT7ULihZ3KRUPM4F83hv5NACoxIrQe87SQhqd13GRw4=
+github.com/ipfs-search/radix/v4 v4.1.2-0.20221008150753-5a6bc0e5ecd7 h1:4e7+yQaS4NAtX+5JT+LdB5rsn0cJq2DDRYx7PemnMX0=
+github.com/ipfs-search/radix/v4 v4.1.2-0.20221008150753-5a6bc0e5ecd7/go.mod h1:ajchozX/6ELmydxWeWM6xCFHVpZ4+67LXHOTOVR0nCE=
+github.com/ipfs-search/radix/v4 v4.1.2-0.20221011201541-285efc40920c h1:XlCHojaHW3khIwzHnlp9D4pQekDj6wxB8tw/WDcyD/M=
+github.com/ipfs-search/radix/v4 v4.1.2-0.20221011201541-285efc40920c/go.mod h1:ajchozX/6ELmydxWeWM6xCFHVpZ4+67LXHOTOVR0nCE=
 github.com/ipfs-search/testify v1.8.1-0.20220714120938-9ebebef47942 h1:BRv7EClOcvXRQH0zpjok74r0KOxxBocQbaIc/FZtUYc=
 github.com/ipfs-search/testify v1.8.1-0.20220714120938-9ebebef47942/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/ipfs/bbloom v0.0.1 h1:s7KkiBPfxCeDVo47KySjK0ACPc5GJRUxFpdyWEuDjhw=
@@ -532,8 +536,6 @@ github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14/go.mod h1:uIp+gprXx
 github.com/rabbitmq/amqp091-go v1.3.4 h1:tXuIslN1nhDqs2t6Jrz3BAoqvt4qIZzxvdbdcxWtHYU=
 github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rueian/rueidis v0.0.77 h1:47D0CukYKTvXvBxvP1sygbw+aoNr2Rb4qFECWDXqJUE=
-github.com/rueian/rueidis v0.0.77/go.mod h1:FwnfDILF2GETrvXcYFlhIiru/7NmSIm1f+7C5kutO0I=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -561,6 +563,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/tilinna/clock v1.0.2 h1:6BO2tyAC9JbPExKH/z9zl44FLu1lImh3nDNKA0kgrkI=
+github.com/tilinna/clock v1.0.2/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 h1:8kxMKmKzXXL4Ru1nyhvdms/JjWt+3YLpvRb/bAjO/y0=
@@ -597,14 +601,12 @@ go.opentelemetry.io/otel/metric v0.32.0 h1:lh5KMDB8xlMM4kwE38vlZJ3rZeiWrjw3As1vc
 go.opentelemetry.io/otel/metric v0.32.0/go.mod h1:PVDNTt297p8ehm949jsIzd+Z2bIZJYQQG/uuHTeWFHY=
 go.opentelemetry.io/otel/sdk v1.10.0 h1:jZ6K7sVn04kk/3DNUdJ4mqRlGDiXAVuIG+MMENpTNdY=
 go.opentelemetry.io/otel/sdk v1.10.0/go.mod h1:vO06iKzD5baltJz1zarxMCNHFpUlUiOy4s65ECtn6kE=
-go.opentelemetry.io/otel/sdk/metric v0.30.0 h1:XTqQ4y3erR2Oj8xSAOL5ovO5011ch2ELg51z4fVkpME=
 go.opentelemetry.io/otel/trace v1.10.0 h1:npQMbR8o7mum8uF95yFbOEJffhs1sbCOfDh8zAJiH5E=
 go.opentelemetry.io/otel/trace v1.10.0/go.mod h1:Sij3YYczqAdz+EhmGhE6TpTxUO5/F/AzrK+kxfGqySM=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
-go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
@@ -657,6 +659,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220630215102-69896b714898 h1:K7wO6V1IrczY9QOQ2WkVpw4JQSwCd52UsxVEirZUfiw=
+golang.org/x/net v0.0.0-20220630215102-69896b714898/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBd
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
+github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -517,6 +519,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
+github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -573,6 +577,8 @@ github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.
 github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c h1:GGsyl0dZ2jJgVT+VvWBf/cNijrHRhkrTjkmp5wg7li0=
 github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c/go.mod h1:xxcJeBb7SIUl/Wzkz1eVKJE/CB34YNrqX2TQI6jY9zs=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
During evaluation of Redis caching *in production*, it was discovered that we were unintentionally overwriting references (filenames) or last seen dates, whenever they were loaded from the cache.

Our code assumes that in updates only non-empty fields are written (so existing values would remain unaltered), while our Redis implementation always wrote the full update.

It was also discovered that only a few items with many references occupied a large amount of RAM, significantly degrading cache performance.

This update:

1. Fully re-implements the Redis cache based on hashmaps, allowing for only some fields to be updated.
2. Implements a Redis set-based cache for items for items which never are updated and mere existence is indexed (invalids, partials). This yields ~10x memory efficiency improvement.
3. Use LZ4-compressed BSON for storing references, significanly reducing overhead for items with many similar references.
4. Provide tests/coverage for aforementioned.
5. Use dynamically generated structs for caching instead of `map[string]interface{}` for less overhead.